### PR TITLE
Patch mic.mm to fix crash on iOS10 beta 3.

### DIFF
--- a/iNDS/core/mic.mm
+++ b/iNDS/core/mic.mm
@@ -9,6 +9,7 @@
 #include "mic.h"
 #import "iNDSMicrophone.h"
 #import "TPCircularBuffer.h"
+#import <AVFoundation/AVFAudio.h>
 
 // For easy timing functions... remove later
 #import <UIKit/UIKit.h>
@@ -25,7 +26,7 @@ void Mic_DeInit(){
 }
 BOOL Mic_Init(){
     printf("Mic Init\n");
-    if (!microphone) {
+    if (!microphone && [[AVAudioSession sharedInstance] respondsToSelector:@selector(requestRecordPermission)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
             microphone = [[iNDSMicrophone alloc] init];
             micEnabled = microphone.micEnabled;


### PR DESCRIPTION
This merge fixes an issue wherein the microphone being accessed was causing a privacy violation crash on iOS 10 beta 3.