### PR TITLE
fixed microphone support for iOS 10 beta 3

### DIFF
--- a/iNDS/core/mic.mm
+++ b/iNDS/core/mic.mm
@@ -26,7 +26,7 @@ void Mic_DeInit(){
 }
 BOOL Mic_Init(){
     printf("Mic Init\n");
-    if (!microphone && [[AVAudioSession sharedInstance] respondsToSelector:@selector(requestRecordPermission)]) {
+    if (!microphone) {
         dispatch_async(dispatch_get_main_queue(), ^{
             microphone = [[iNDSMicrophone alloc] init];
             micEnabled = microphone.micEnabled;

--- a/iNDS/support/iNDS-Info.plist
+++ b/iNDS/support/iNDS-Info.plist
@@ -133,6 +133,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone support is required for some games.</string>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Pull request #179 allowed games to run on iOS 10 beta 3, but stopped microphone support from working.
The reason that iNDS was crashing when attempting to run a game in iOS 10 seems to be a new requirement for there to be a plist entry for NSMicrophoneUsageDescription (see here: https://forums.developer.apple.com/thread/51985)

Removing the changes to the 'if' clause from the previous pull request and adding the entry mentioned above to the plist file seems to allow games to run in iOS 10 beta 3, with microphone support functioning.

However, there's a possible issue: game audio seems to cut out after a few seconds if the microphone is enabled. (I'm not sure whether this is a separate issue to getting microphone support working at all.)
Tested with Nintendogs: the audio cuts out soon after entering the screen where you can buy a dog for the first time. If a dog has already been purchased, audio cuts out when launching the game and reaching the initial 'Nintendogs' start screen. Disabling the microphone in iNDS settings restores game audio.