### PR TITLE
Add toggle for using mirrored display as top screen.

### DIFF
--- a/iNDS/AppDelegate.m
+++ b/iNDS/AppDelegate.m
@@ -519,7 +519,9 @@
         interfaceSection.items = @[[[WCEasySettingsSwitch alloc] initWithIdentifier:@"fullScreenSettings"
                                                                               title:@"Full Screen Settings"],
                                    [[WCEasySettingsSwitch alloc] initWithIdentifier:@"showFPS"
-                                                                              title:@"Show FPS"]];
+                                                                              title:@"Show FPS"],
+                                   [[WCEasySettingsSwitch alloc] initWithIdentifier:@"mirrorDisplay"
+                                                                              title:@"Mirror Display"]];
         
         
         // Credits

--- a/iNDS/iNDSEmulatorViewController.mm
+++ b/iNDS/iNDSEmulatorViewController.mm
@@ -354,6 +354,9 @@ enum VideoFilter : NSUInteger {
         int filterTranslate[] = {NONE, EPX, SUPEREAGLE, _2XSAI, SUPER2XSAI, BRZ2x, LQ2X, BRZ3x, HQ2X, HQ4X, BRZ4x, BRZ5x};
         NSInteger filter = [[NSUserDefaults standardUserDefaults] integerForKey:@"videoFilter"];
         EMU_setFilter(filterTranslate[filter]);
+        
+        // Mirror Display
+        [self performSelector:@selector(screenChanged:) withObject:notification];
     }
     self.directionalControl.style = [defaults integerForKey:@"controlPadStyle"];
     self.fpsLabel.hidden = ![defaults integerForKey:@"showFPS"];
@@ -403,7 +406,7 @@ enum VideoFilter : NSUInteger {
     self.controllerContainerView.alpha = [[NSUserDefaults standardUserDefaults] floatForKey:@"controlOpacity"];
     self.startButton.alpha = [[NSUserDefaults standardUserDefaults] floatForKey:@"controlOpacity"];
     self.selectButton.alpha = [[NSUserDefaults standardUserDefaults] floatForKey:@"controlOpacity"];
-    if ([UIScreen screens].count > 1) {
+    if ([UIScreen screens].count > 1 && ![[NSUserDefaults standardUserDefaults] boolForKey:@"mirrorDisplay"]) {
         CGSize screenSize = [UIScreen screens][1].bounds.size;
         CGSize viewSize = CGSizeMake(MIN(screenSize.width, screenSize.height * 1.333), MIN(screenSize.width, screenSize.height * 1.333) * 0.75);
         glkView[0].frame = CGRectMake(screenSize.width/2 - viewSize.width/2, screenSize.height/2 - viewSize.height/2, viewSize.width, viewSize.height);
@@ -420,7 +423,7 @@ enum VideoFilter : NSUInteger {
 - (void)screenChanged:(NSNotification*)notification
 {
     [self pauseEmulation];
-    if ([UIScreen screens].count > 1) {
+    if ([UIScreen screens].count > 1 && ![[NSUserDefaults standardUserDefaults] boolForKey:@"mirrorDisplay"]) {
         UIScreen *extScreen = [UIScreen screens][1];
         extScreen.currentMode = extScreen.availableModes[0];
         extWindow = [[UIWindow alloc] initWithFrame:extScreen.bounds];
@@ -466,7 +469,7 @@ enum VideoFilter : NSUInteger {
     //self.context.multiThreaded = YES;
     NSLog(@"Is multi: %d", self.context.isMultiThreaded);
     
-    if ([UIScreen screens].count > 1) {
+    if ([UIScreen screens].count > 1 && ![[NSUserDefaults standardUserDefaults] boolForKey:@"mirrorDisplay"]) {
         UIScreen *extScreen = [UIScreen screens][1];
         extScreen.currentMode = extScreen.availableModes[0];
         extWindow = [[UIWindow alloc] initWithFrame:extScreen.bounds];

--- a/iNDS/settings/Defaults.plist
+++ b/iNDS/settings/Defaults.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>mirrorDisplay</key>
+	<false/>
 	<key>videoFilter</key>
 	<integer>5</integer>
 	<key>enableMic</key>


### PR DESCRIPTION
This might be useful for streamers or people recording gameplay, where
both screens need to be visible. It has been tested on an iPad Pro 9.7
with X-Mirage.

This is also my first time working on/modifying an emulator’s code, so
the code quality may not be great.