### PR TITLE
Refresh the states when it's brought foreground

### DIFF
--- a/iNDS/iNDSGameTableView.m
+++ b/iNDS/iNDSGameTableView.m
@@ -21,6 +21,8 @@
 {
     [super viewDidLoad];
     self.navigationItem.title = _game.gameTitle;
+    
+    [[AppDelegate sharedInstance].currentEmulatorViewController.settingsContainer addObserver:self forKeyPath:@"hidden" options:NSKeyValueObservingOptionNew context:nil];
 }
 
 -(void) viewWillAppear:(BOOL)animated
@@ -28,6 +30,20 @@
     [super viewWillAppear:animated];
     [self.tableView reloadData];
     
+}
+
+- (void)dealloc
+{
+    [[AppDelegate sharedInstance].currentEmulatorViewController.settingsContainer removeObserver:self forKeyPath:@"hidden" context:nil];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
+{
+    if (object == [AppDelegate sharedInstance].currentEmulatorViewController.settingsContainer) {
+        if ([change[NSKeyValueChangeNewKey] isEqual:@(NO)]) {
+            [self.tableView reloadData];
+        }
+    }
 }
 
 #pragma mark - Table View


### PR DESCRIPTION
Use case:
- Player saves a state manually
- Player doesn't like the progress and reloads the state
- Game is now past 3min and player doesn't like the progress either, he wants to reload that state again
- Now the underlying data is actually an auto saved state, while it's still listed as the player's state.

Fix:
Force refreshing the state list every time it's brought up. We could detect the file change or listen to auto save event but that's too costly.
